### PR TITLE
Adding text file support and an editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/lib/plugins/captions.js
+++ b/lib/plugins/captions.js
@@ -6,7 +6,7 @@ const { exec } = require('shelljs');
 
 class CaptionsPlugin {
   constructor({ captionsFolder, minCaptions }) {
-    this.captions = this.loadSubtitles(captionsFolder);
+    this.captions = this.loadCaptionFiles(captionsFolder);
     this.minCaptions = minCaptions;
   }
 
@@ -26,9 +26,26 @@ class CaptionsPlugin {
     );
   }
 
-  loadSubtitles(folder) {
-    return glob.sync(`${folder}/*.srt`).reduce((memo, file) => {
-      const strings = this.loadSubtitle(file);
+  loadTextFile(file) {
+    const lines = readFileSync(file, 'UTF-8').toString().replace("\r\n", "\n").replace("\r", "\n").split("\n");
+    return lines.filter(line => line.trim() !== '')
+  }
+
+  loadCaptionFiles(folder) {
+    return glob.sync(`${folder}/*.{srt,txt}`).reduce((memo, file) => {
+      const extension = file.substr(file.lastIndexOf('.') + 1);
+      let strings
+      switch (extension) {
+        case 'srt':
+          strings = this.loadSubtitle(file);
+          break;
+        case 'txt':
+          strings = this.loadTextFile(file);
+          break;
+        default:
+          console.log(`Not sure how to parse the file ${file}`);
+      }
+
       if (Array.isArray(strings)) {
         memo.push.apply(memo, strings);
       } else {


### PR DESCRIPTION
This adds support for `*.txt` files as caption sources, and an `.editorconfig` file to make sure the usage of spaces and whatnot stays sane!

How I tested:

1. set up everything as usual -- create a `videos/` folder and a `captions/` folder and a `stills/` folder.
2. drop some bold videos in that videos folder
3. create a text file like this in the `captions/` folder, not the extraneous empty lines that should be filtered out and never used...

```
hello there

lol wat
haha



hello

```

4. run `./bin/stills.js --captions=100` and witness the glorious usage of your text, such as:

![diners drive ins and dives - season 23 episode special - best of the beach 1409s](https://user-images.githubusercontent.com/770158/53289126-ccdd8080-375f-11e9-8937-3eef89df853b.png)

@shahkashani 