### PR TITLE
feat: replace profanity filter

### DIFF
--- a/lib/moderation/words.js
+++ b/lib/moderation/words.js
@@ -1,20 +1,25 @@
-const BadWords = require('bad-words');
+const { isProfane } = require('no-profanity');
 const { flatten } = require('lodash');
 
 class ModerationWords {
+  includes = [];
+  excludes = [];
+
   constructor({ bannedWords = [], allowedWords = [] }) {
-    this.badWords = new BadWords();
     if (bannedWords.length > 0) {
-      this.badWords.addWords(...bannedWords);
+      this.includes = [...bannedWords, ...this.includes];
     }
     if (allowedWords.length > 0) {
-      this.badWords.removeWords(...allowedWords);
+      this.excludes = [...allowedWords, ...this.excludes];
     }
   }
 
   async validate(text) {
     const useText = Array.isArray(text) ? flatten(text).join(' ') : text;
-    return !this.badWords.isProfane(useText);
+    return !isProfane({
+      testString: useText,
+      options: { includes: this.includes, excludes: this.excludes }
+    });
   }
 }
 

--- a/lib/taggers/captions.js
+++ b/lib/taggers/captions.js
@@ -1,4 +1,4 @@
-const filter = new (require('bad-words'))();
+const { replaceProfanities } = require('no-profanity');
 const { uniq, compact } = require('lodash');
 const rake = require('rake-js').default;
 
@@ -9,9 +9,9 @@ class TaggerCaptions {
 
   cleanText(text) {
     try {
-      return filter
-        .clean((text || '').replace(/[\[\]\(\)]/g, ''))
-        .replace(/[?!,.]$/, '');
+      return replaceProfanities(
+        (text || '').replace(/[\[\]\(\)]/g, '')
+      ).replace(/[?!,.]$/, '');
     } catch (err) {
       return text;
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@vladmandic/face-api": "^0.30.3",
     "@vladmandic/human": "^3.0.5",
     "aws-sdk": "^2.927.0",
-    "bad-words": "^3.0.4",
+    "no-profanity": "^1.4.2",
     "canvas": "^2.11.2",
     "canvas-txt": "^3.0.0",
     "compromise": "^13.11.2",


### PR DESCRIPTION
Hi there!

I've updated the profanity filter used internally, and replaced the `bad-words` package with the `no-profanity` package. Full disclosure: I've built the no-profanity package to replace the `bad-words` package as it was abandoned.

The no-profanity filter filters much quicker (about 150 times), as it uses a single regex as opposed to a for-loop going through all banned words one by one, and also the list of known profanities is greater, and not a single profanity from the `bad-words` package has been removed so it's  backwards compatible.

Unfortunately I somehow keep running into issues locally installing all the packages, so I haven't been able to update the `package-lock.json` but all the code should work as expected.

Let me know if you need anything from me to get it merged!