### PR TITLE
Update tumblr.js to v4

### DIFF
--- a/lib/destinations/tumblr.js
+++ b/lib/destinations/tumblr.js
@@ -118,7 +118,7 @@ class DestinationTumblr {
       return {
         type: 'image',
         alt_text: this.getAlt(index, captions, analysis, useGlyphs),
-        media: createReadStream(image.filenmae)
+        media: createReadStream(image.filename)
       };
     });
 

--- a/lib/destinations/tumblr.js
+++ b/lib/destinations/tumblr.js
@@ -145,14 +145,14 @@ class DestinationTumblr {
       };
       console.log('🙋‍♂️ Submitting data');
       console.log(JSON.stringify(sendData, null, 2));
-      const { response } = await this.client.editPost(
+      const response = await this.client.editPost(
         this.blogName,this.ask.id,
         sendData,
       );
       return response;
     }
 
-    const { response } = await this.client.createPost(
+    const response = await this.client.createPost(
       this.blogName,
       {
         tags,
@@ -217,7 +217,7 @@ class DestinationTumblr {
       'source_url'
     ]);
     fields.tags = (fields.tags || []).join(',');
-    const { response } = await this.client.createPost(
+    const response = await this.client.createPost(
       this.blogName,
       {
         ...fields,

--- a/lib/destinations/tumblr.js
+++ b/lib/destinations/tumblr.js
@@ -20,12 +20,12 @@ class DestinationTumblr {
     highlightColor = '#FF492F',
     ask = null
   }) {
+    /** @type {tumblr.Client} */
     this.client = tumblr.createClient({
       token,
       consumer_key: consumerKey,
       consumer_secret: consumerSecret,
       token_secret: tokenSecret,
-      returnPromises: true
     });
     this.blogName = blogName;
     this.reblog = reblog;
@@ -37,14 +37,6 @@ class DestinationTumblr {
 
   get name() {
     return 'tumblr';
-  }
-
-  getBaseParams(apiPath) {
-    return {
-      ...this.client.requestOptions,
-      url: this.client.baseUrl + apiPath,
-      oauth: this.client.credentials
-    };
   }
 
   getAlt(index, captions, analysis, useGlyphs) {
@@ -114,34 +106,6 @@ class DestinationTumblr {
     };
   }
 
-  async makeNpfRequestForm(apiPath, formData, body, method = 'post') {
-    return new Promise((resolve, reject) => {
-      this.client.request[method](
-        {
-          ...this.getBaseParams(apiPath),
-          headers: {
-            'Content-Type': 'multipart/form-data'
-          },
-          formData: {
-            json: JSON.stringify(body),
-            ...formData
-          }
-        },
-        (err, _response, body) => {
-          if (err) {
-            return reject(err);
-          }
-          try {
-            body = JSON.parse(body);
-          } catch (e) {
-            return reject(`Malformed Response: ${body}`);
-          }
-          resolve(body);
-        }
-      );
-    });
-  }
-
   async createPhotoPostNpf(
     images,
     tags,
@@ -150,20 +114,11 @@ class DestinationTumblr {
     analysis,
     useGlyphs
   ) {
-    const formData = images.reduce((memo, image, index) => {
-      memo[`pic${index}`] = createReadStream(image.filename);
-      return memo;
-    }, {});
-
     const imageContent = images.map((image, index) => {
       return {
         type: 'image',
         alt_text: this.getAlt(index, captions, analysis, useGlyphs),
-        media: [
-          {
-            identifier: `pic${index}`
-          }
-        ]
+        media: createReadStream(image.filenmae)
       };
     });
 
@@ -185,25 +140,22 @@ class DestinationTumblr {
       const sendData = {
         layout,
         content,
-        tags: tags.join(','),
+        tags,
         state: this.publishState
       };
       console.log('🙋‍♂️ Submitting data');
       console.log(JSON.stringify(sendData, null, 2));
-      const { response } = await this.makeNpfRequestForm(
-        `/blog/${this.blogName}/posts/${this.ask.id}`,
-        formData,
+      const { response } = await this.client.editPost(
+        this.blogName,this.ask.id,
         sendData,
-        'put'
       );
       return response;
     }
 
-    const { response } = await this.makeNpfRequestForm(
-      `/blog/${this.blogName}/posts`,
-      formData,
+    const { response } = await this.client.createPost(
+      this.blogName,
       {
-        tags: tags.join(','),
+        tags,
         state: this.publishState,
         content: [...imageContent, ...(textContent ? [textContent] : [])]
       }
@@ -265,9 +217,8 @@ class DestinationTumblr {
       'source_url'
     ]);
     fields.tags = (fields.tags || []).join(',');
-    const { response } = await this.makeNpfRequestForm(
-      `/blog/${this.blogName}/posts`,
-      {},
+    const { response } = await this.client.createPost(
+      this.blogName,
       {
         ...fields,
         state: this.publishState

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "string-similarity": "^4.0.4",
         "svgdom": "^0.1.10",
         "tinycolor2": "^1.4.2",
-        "tumblr.js": "^2.0.2",
+        "tumblr.js": "^4.0.0-alpha.1",
         "twitter": "^1.7.1",
         "wasm-vips": "^0.0.4",
         "writegif": "^1.1.0",
@@ -2189,9 +2189,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.10",
@@ -2213,6 +2213,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -3447,14 +3455,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
       "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -4048,14 +4048,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/find-up": {
@@ -7768,6 +7760,11 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
+    "node_modules/oauth": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.0.tgz",
+      "integrity": "sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q=="
+    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -8346,23 +8343,6 @@
       "integrity": "sha1-0lrCAKd7bXD0ASfKFxoQ4zyFRt4=",
       "engines": {
         "node": ">=0.10.21"
-      }
-    },
-    "node_modules/query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/querystring": {
@@ -9039,14 +9019,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9109,14 +9081,6 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -9657,16 +9621,31 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tumblr.js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-2.0.2.tgz",
-      "integrity": "sha512-+E0VWoo+LCDD67e3f6+D1RvmypGypM0N4je5WLFjZl0sbRy4XWiwhqFECZVoontZfRs2rTGzdoY/4Xupw/eFoQ==",
+      "version": "4.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-4.0.0-alpha.2.tgz",
+      "integrity": "sha512-u+i3hcBJ9xphb7YFF4/7oX/kPp/+SbY7DNq196ojnf0WzbQ1Em+DzvI7Qddl+Rf0Ht8sGNGMckLq6CHptb3GSA==",
       "dependencies": {
-        "lodash": "^4.17.11",
-        "query-string": "^6.1.0",
-        "request": "^2.88.0"
+        "@types/node": ">=16",
+        "@types/oauth": "^0.9.1",
+        "form-data": "^4.0.0",
+        "oauth": "^0.10.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/tumblr.js/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tunnel": {
@@ -12096,9 +12075,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "@types/node-fetch": {
       "version": "2.5.10",
@@ -12119,6 +12098,14 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/offscreencanvas": {
@@ -13115,11 +13102,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
       "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
     "decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -13588,11 +13570,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-up": {
       "version": "4.1.0",
@@ -16355,6 +16332,11 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
+    "oauth": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.0.tgz",
+      "integrity": "sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q=="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -16774,17 +16756,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
       "integrity": "sha1-0lrCAKd7bXD0ASfKFxoQ4zyFRt4="
-    },
-    "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -17325,11 +17296,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -17375,11 +17341,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -17821,13 +17782,26 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tumblr.js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-2.0.2.tgz",
-      "integrity": "sha512-+E0VWoo+LCDD67e3f6+D1RvmypGypM0N4je5WLFjZl0sbRy4XWiwhqFECZVoontZfRs2rTGzdoY/4Xupw/eFoQ==",
+      "version": "4.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-4.0.0-alpha.2.tgz",
+      "integrity": "sha512-u+i3hcBJ9xphb7YFF4/7oX/kPp/+SbY7DNq196ojnf0WzbQ1Em+DzvI7Qddl+Rf0Ht8sGNGMckLq6CHptb3GSA==",
       "requires": {
-        "lodash": "^4.17.11",
-        "query-string": "^6.1.0",
-        "request": "^2.88.0"
+        "@types/node": ">=16",
+        "@types/oauth": "^0.9.1",
+        "form-data": "^4.0.0",
+        "oauth": "^0.10.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "tunnel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "string-similarity": "^4.0.4",
         "svgdom": "^0.1.10",
         "tinycolor2": "^1.4.2",
-        "tumblr.js": "^4.0.0-alpha.1",
+        "tumblr.js": "^4.0.0",
         "twitter": "^1.7.1",
         "wasm-vips": "^0.0.4",
         "writegif": "^1.1.0",
@@ -9621,9 +9621,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tumblr.js": {
-      "version": "4.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-4.0.0-alpha.2.tgz",
-      "integrity": "sha512-u+i3hcBJ9xphb7YFF4/7oX/kPp/+SbY7DNq196ojnf0WzbQ1Em+DzvI7Qddl+Rf0Ht8sGNGMckLq6CHptb3GSA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-4.0.0.tgz",
+      "integrity": "sha512-ahukRF11oiZjPr1COKyE/MlMXpTda75jKQoSA0VcETyIKZ5XHkJF4N5bq/v3+zaH/SDYDK+vAFTvGjJAoGYTtg==",
       "dependencies": {
         "@types/node": ">=16",
         "@types/oauth": "^0.9.1",
@@ -17782,9 +17782,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tumblr.js": {
-      "version": "4.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-4.0.0-alpha.2.tgz",
-      "integrity": "sha512-u+i3hcBJ9xphb7YFF4/7oX/kPp/+SbY7DNq196ojnf0WzbQ1Em+DzvI7Qddl+Rf0Ht8sGNGMckLq6CHptb3GSA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tumblr.js/-/tumblr.js-4.0.0.tgz",
+      "integrity": "sha512-ahukRF11oiZjPr1COKyE/MlMXpTda75jKQoSA0VcETyIKZ5XHkJF4N5bq/v3+zaH/SDYDK+vAFTvGjJAoGYTtg==",
       "requires": {
         "@types/node": ">=16",
         "@types/oauth": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "string-similarity": "^4.0.4",
     "svgdom": "^0.1.10",
     "tinycolor2": "^1.4.2",
-    "tumblr.js": "^4.0.0-alpha.2",
+    "tumblr.js": "^4.0.0",
     "twitter": "^1.7.1",
     "wasm-vips": "^0.0.4",
     "writegif": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "string-similarity": "^4.0.4",
     "svgdom": "^0.1.10",
     "tinycolor2": "^1.4.2",
-    "tumblr.js": "^2.0.2",
+    "tumblr.js": "^4.0.0-alpha.2",
     "twitter": "^1.7.1",
     "wasm-vips": "^0.0.4",
     "writegif": "^1.1.0",


### PR DESCRIPTION
Upgrade tumblr.js lib to v4.
Remove the helper methods from the tumblr destination that rely on `request` and use the supported client methods (`createPost`, etc…).

I tested this out by using stills to create and upload some stills from a sample video to a Tumblr test blog.

This applies some of the necessary changes to update tumblr.js to v4.

- No more `returnPromises` (promises are returned when no callback is provided)
- NPF post creation with media uploads is supported via `createPost`


This was very helpful for me while working on the v4 release and validating its behavior. I was fortunate to find some real-world OSS using the lib like this.