### PR TITLE
Pass file paths to ffprobe/ffmpeg as arguments rather than interpolating them into a shell string

### DIFF
--- a/lib/content/utils.js
+++ b/lib/content/utils.js
@@ -1,4 +1,5 @@
 const { exec } = require('shelljs');
+const { execFileSync } = require('child_process');
 const { random } = require('lodash');
 
 const shell = (cmd) => {
@@ -9,10 +10,27 @@ const shell = (cmd) => {
   return result.stdout;
 };
 
+// No shell: each argument is passed to the process literally, so a filename
+// cannot be interpreted as syntax.
+const shellArgs = (bin, args) => {
+  try {
+    return execFileSync(bin, args, { encoding: 'utf8' });
+  } catch (err) {
+    const stderr = err.stderr ? err.stderr.toString().trim() : err.message;
+    throw new Error(`Shell command error: ${stderr}\n> ${bin} ${args.join(' ')}`);
+  }
+};
+
 const getVideoLength = (file) => {
-  const output = shell(
-    `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${file}"`
-  );
+  const output = shellArgs('ffprobe', [
+    '-v',
+    'error',
+    '-show_entries',
+    'format=duration',
+    '-of',
+    'default=noprint_wrappers=1:nokey=1',
+    file,
+  ]);
   return output.trim();
 };
 

--- a/lib/content/video.js
+++ b/lib/content/video.js
@@ -55,9 +55,18 @@ class ContentVideo {
       if (isExisting) {
         console.log(`🥚 Video already exists, skipping.`);
       } else {
-        execCmd(
-          `ffmpeg -i "${input}" -ss ${sec} -t ${length} -c copy -y "${file}"`
-        );
+        execCmd('ffmpeg', [
+          '-i',
+          input,
+          '-ss',
+          String(sec),
+          '-t',
+          String(length),
+          '-c',
+          'copy',
+          '-y',
+          file,
+        ]);
       }
 
       const info = getImageInfo(file);

--- a/lib/utils/exec-cmd.js
+++ b/lib/utils/exec-cmd.js
@@ -1,9 +1,30 @@
 const { exec } = require('shelljs');
+const { execFileSync } = require('child_process');
 
-module.exports = execCmd = (cmd) => {
+// Two calling conventions:
+//
+//   execCmd('ffmpeg -i "foo.mp4" ...')        legacy, goes through a shell
+//   execCmd('ffmpeg', ['-i', 'foo.mp4', ...]) no shell, arguments passed literally
+//
+// Prefer the second whenever any part of the command comes from outside this
+// module — a filename, a path, anything a caller supplied. With a shell in the
+// loop, quoting a value does not make it safe: double quotes stop word-splitting
+// but not command substitution, so `$(...)` inside a filename still executes.
+module.exports = execCmd = (cmd, args) => {
   if (!cmd) {
     return;
   }
+
+  if (Array.isArray(args)) {
+    try {
+      return execFileSync(cmd, args, { encoding: 'utf8' });
+    } catch (err) {
+      const stderr = err.stderr ? err.stderr.toString() : err.message;
+      console.log(`🐞 Oops: ${stderr}\n> ${cmd} ${args.join(' ')}`);
+      return '';
+    }
+  }
+
   const result = exec(cmd, { silent: true });
   if (result.code !== 0) {
     console.log(`🐞 Oops: ${result.stderr}\n> ${cmd}`);

--- a/lib/utils/get-image-info.js
+++ b/lib/utils/get-image-info.js
@@ -1,13 +1,28 @@
-const { exec } = require('shelljs');
+const { execFileSync } = require('child_process');
 
 const getImageInfo = (file) => {
-  const cmd = `ffprobe -v quiet -print_format json -show_format -show_streams "${file}"`;
-  const result = exec(cmd, { silent: true });
-  if (result.code !== 0) {
-    console.error(result);
+  // No shell: `file` is passed to ffprobe literally and cannot be interpreted
+  // as shell syntax.
+  let stdout;
+  try {
+    stdout = execFileSync(
+      'ffprobe',
+      [
+        '-v',
+        'quiet',
+        '-print_format',
+        'json',
+        '-show_format',
+        '-show_streams',
+        file,
+      ],
+      { encoding: 'utf8' }
+    );
+  } catch (err) {
+    console.error(err);
     return null;
   }
-  const json = JSON.parse(result.stdout.trim());
+  const json = JSON.parse(stdout.trim());
   const stream = json.streams[0];
   const numFrames = parseInt(stream.nb_frames || 1, 10);
   const width = stream.width;


### PR DESCRIPTION
Hi — this fixes a command injection in the `ffprobe` and `ffmpeg` invocations. Four files, and no existing caller has to change.

### The problem

Paths are interpolated into shell command strings:

```js
// lib/content/utils.js
`ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${file}"`

// lib/utils/get-image-info.js
`ffprobe -v quiet -print_format json -show_format -show_streams "${file}"`

// lib/content/video.js
`ffmpeg -i "${input}" -ss ${sec} -t ${length} -c copy -y "${file}"`
```

The double quotes stop word-splitting, but they do **not** stop command substitution — `$( )` and backticks are still expanded by the shell *inside* double quotes. A filename containing one gets executed rather than read.

**Where the values come from is what makes this worth fixing.** `input` and `output` are the first two positional arguments of the public `content.Video` / `Still` / `Gif` `#generate`, so a programmatic caller controls them directly.

But the path I'd draw your attention to is `sources.Local`: it globs a watched directory and derives both `input` and `output` from the filenames it finds. On that path the value comes from **whoever can write a file into the media folder** — no API access needed. For a setup where that directory is fed by uploads, a sync folder, or anything automated, a filename is enough.

### The fix

`exec-cmd.js` gains an argument-array form:

```js
execCmd('ffmpeg', ['-i', input, '-ss', String(sec), ...])   // no shell
execCmd('ffmpeg -i "foo.mp4" ...')                          // unchanged, still works
```

The string form is left exactly as it was, so this is backward-compatible and none of the other five call sites need touching. `getVideoLength` and `getImageInfo` call `ffprobe` through `execFileSync` directly.

Quotes are dropped at each converted site deliberately — quoting is a shell concern, and keeping it would put the literal quote characters into the path. That's the thing worth checking when reviewing.

### Verification

Confirmed that a filename containing a command substitution is now received by the child process as a literal string and is not evaluated. `getImageInfo` keeps its existing contract of returning `null` on failure; the `ffprobe`/`ffmpeg` arguments are otherwise byte-for-byte the same in the same order.

### One thing I deliberately did not change

`lib/effects/exec.js`:

```js
execSync(`convert "${file}" ${cmd} "${file}"`);
```

`cmd` here is *by design* a fragment of a shell command supplied by the caller, so it isn't really "injection" so much as the intended interface — and fixing it properly means changing that API. It also isn't re-exported from the root barrel, so it's reachable only by deep import. Left alone as out of scope, but flagging it so the decision is yours rather than an oversight.

### If you agree with the fix

Worth publishing a patched version to npm, since the fix only reaches users on install.

Optionally, enabling **private vulnerability reporting** (Settings → Security) would give future reports a private channel — it's currently off, which is why this is a public PR.

Happy to adjust anything or split it up if you'd prefer smaller changes.