### PR TITLE
Finish the shell-injection fix: two more paths reach a shell in 25.24.1

### DIFF
--- a/lib/content/utils.js
+++ b/lib/content/utils.js
@@ -17,7 +17,9 @@ const shellArgs = (bin, args) => {
     return execFileSync(bin, args, { encoding: 'utf8' });
   } catch (err) {
     const stderr = err.stderr ? err.stderr.toString().trim() : err.message;
-    throw new Error(`Shell command error: ${stderr}\n> ${bin} ${args.join(' ')}`);
+    throw new Error(
+      `Shell command error: ${stderr}\n> ${bin} ${args.join(' ')}`
+    );
   }
 };
 
@@ -29,7 +31,7 @@ const getVideoLength = (file) => {
     'format=duration',
     '-of',
     'default=noprint_wrappers=1:nokey=1',
-    file,
+    file
   ]);
   return output.trim();
 };

--- a/lib/content/utils/make-gif.js
+++ b/lib/content/utils/make-gif.js
@@ -36,7 +36,7 @@ const makeGif = async (
           const sizeMb = statSync(file).size / (1024 * 1024);
           if (sizeMb > GIF_SIZE_LIMIT_MB) {
             console.log(`GIF size exceed ${GIF_SIZE_LIMIT_MB}MB, compressing.`);
-            execCmd(`gifsicle --lossy=20 -O3 "${file}" -o "${file}"`);
+            execCmd('gifsicle', ['--lossy=20', '-O3', file, '-o', file]);
             const newSizeMb = statSync(file).size / (1024 * 1024);
             console.log(`New file size: ${round(newSizeMb, 2)}MB`);
           }

--- a/lib/content/video.js
+++ b/lib/content/video.js
@@ -65,7 +65,7 @@ class ContentVideo {
           '-c',
           'copy',
           '-y',
-          file,
+          file
         ]);
       }
 

--- a/lib/effects/exec.js
+++ b/lib/effects/exec.js
@@ -1,5 +1,26 @@
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
+// Single-quote a value for /bin/sh. Everything between single quotes is
+// literal, and an embedded quote is written as '\''. Double quotes are not
+// enough: the shell still expands $(...) and backticks inside them, so a
+// filename containing one is executed rather than opened.
+const quote = (value) => `'${String(value).replace(/'/g, `'\\''`)}'`;
+
+// Two calling conventions, same idea as utils/exec-cmd:
+//
+//   exec(image, '-flip -rotate 90')         cmd is a shell fragment
+//   exec(image, ['-flip', '-rotate', '90']) no shell, arguments passed literally
+//
+// The string form is kept because cmd is deliberately a fragment of ImageMagick
+// syntax — \( \), globs and quoting all have to keep working — and that is a
+// choice the caller makes about their own command line. file is not: it is a
+// path this library generated from a source filename, so it is quoted in the
+// string form and is a plain argument in the array form. Prefer the array form
+// in new code; it takes the shell out of the loop entirely.
 module.exports = async ({ file }, cmd) => {
-  execSync(`convert "${file}" ${cmd} "${file}"`);
+  if (Array.isArray(cmd)) {
+    execFileSync('convert', [file, ...cmd, file]);
+    return;
+  }
+  execSync(`convert ${quote(file)} ${cmd} ${quote(file)}`);
 };

--- a/lib/stills/frames.js
+++ b/lib/stills/frames.js
@@ -103,9 +103,16 @@ class Frames {
       const widthCmd = this.width
         ? `,scale=${this.width}:${this.width}/dar`
         : '';
-      execCmd(
-        `ffmpeg -i "${input}" -q:v 5 -filter_complex "fps=${this.fps}${widthCmd}" -y "${originalBase} %04d.png"`
-      );
+      execCmd('ffmpeg', [
+        '-i',
+        input,
+        '-q:v',
+        '5',
+        '-filter_complex',
+        `fps=${this.fps}${widthCmd}`,
+        '-y',
+        `${originalBase} %04d.png`
+      ]);
       this.frames = sync(`${originalBase} [0-9][0-9][0-9][0-9].png`).map(
         (file, index) => {
           const buffer = readFileSync(file);

--- a/lib/utils/get-image-info.js
+++ b/lib/utils/get-image-info.js
@@ -14,7 +14,7 @@ const getImageInfo = (file) => {
         'json',
         '-show_format',
         '-show_streams',
-        file,
+        file
       ],
       { encoding: 'utf8' }
     );


### PR DESCRIPTION

Thanks for turning #29 around so quickly and cutting 25.24.1 — that was a fast response and the
change itself is correct.

It is not complete, though, and I should have caught this the first time rather than after you had
already shipped. Sorry for the second round.

## What #29 fixed, and what it missed

#29 converted the three sinks my original report named — `getVideoLength`, `getImageInfo` and
`video.js`'s ffmpeg call. Those are genuinely fixed.

But the report named sinks, not values, and the value it was really about — a path derived from a
source filename — reaches two more shells that the report never mentioned:

- **`lib/stills/frames.js`** builds its `ffmpeg` invocation as a single string and passes it to the
  legacy string form of `execCmd`, which still goes through shelljs. This is the one that matters:
  it is reachable end to end from the public API. `ContentVideo#generate` returns no `buffers` key,
  so `Frames#expand()` falls through to the `isVideo()` branch, and `originalBase` there comes from
  the filename `Stills#setup() → restore() → prepare()` hands down. On the `sources.Local` path that
  filename is whatever is sitting in the watched folder.
- **`lib/content/utils/make-gif.js`** does the same thing with `gifsicle`, on the output path, when
  a GIF goes over the size limit.

Both are the exact defect #29 described — double quotes stop word-splitting but not command
substitution — just in files that report did not list.

I think this is worth more attention than a normal bug report, for one reason: **25.24.1 is
publicly a security release.** Anyone who read #29, bumped, and moved on now has a version that
reads as patched and is still injectable on the `content: Video` path. A quiet incomplete fix is
worse than a known-open one, because it stops people looking.

The shape of the input, without a working string: a filename containing shell command-substitution
syntax before its extension. It has to survive `sources.Local`'s glob (so a real video extension)
and `path.parse().name` (so the substitution sits before the final dot). Nothing else constrains it
— the file's contents are never inspected, and ffmpeg does not even have to be installed, because
the shell expands the substitution before it goes looking for a binary.

## The fix

- `frames.js` and `make-gif.js` now use **the argument-array form of `execCmd` you already merged in
  25.24.1** — no new mechanism, same call site, same function. The ffmpeg argv is a literal
  decomposition of the old string: the `-filter_complex` value stays a single argument, and so does
  the `"<base> %04d.png"` output pattern, space included.
- `lib/effects/exec.js` is the awkward one, because it has two values with two different trust
  levels in one command. `cmd` is a fragment of ImageMagick syntax the caller wrote — `\( \)`,
  globs, quoting all have to keep working, so collapsing it into a single argv element would
  quietly change what every existing effect does. `file` is not the caller's; this library
  generated it from a source filename. So the two are separated rather than the API being rewritten:
  the string form is kept and `cmd` keeps its exact current meaning, but `file` is single-quoted,
  which the shell does not re-parse. An array form is added alongside it (`exec(image, ['-flip'])`)
  that takes the shell out entirely — the same two-conventions pattern `execCmd` already has. No
  existing caller changes.

Deliberately **not changed**: `lib/filters/embed.js`. Its unquoted `width`/`height`/`rotate` come
from the filter's own `positions` config rather than from a filename, and its `file`/`original` are
the random temp names `process-as-file` generates, so nothing outside your control reaches it. Its
commands also use `\( \)` grouping, which does not decompose into argv mechanically — getting that
wrong would change the rendered output rather than fail loudly, which is not a trade I want to make
inside a security fix. Happy to do it as a separate PR if you want the consistency.

There is also a small third commit that just runs prettier over the files 25.24.1 touched (a few
trailing commas against your `trailingComma: none`). Drop it if you would rather keep the diff to
the fix.

## Verification

Both arms were run in the same disposable container, in the same session, against the **published**
`stills@25.24.1` from npm — because the whole reason this PR exists is that a merged fix shipped
incomplete and nobody re-ran anything against the published artifact.

- **Control** — published 25.24.1, untouched: all three canaries fire.
- **Subject** — the same install with only these files replaced: no canary fires, and the crafted
  filename is observed arriving at `ffmpeg`, `convert` and `gifsicle` as one literal, unexpanded
  argument. That second half matters — otherwise "no canary" would be indistinguishable from "the
  payload never got there."
- **Benign inputs produce byte-identical argv in both arms**, for the ffmpeg call and for three
  different `cmd` fragments through the exec effect, including one with a quoted hex colour and one
  with `\( \)` grouping. The patch does not change what gets executed.

(ffmpeg/ImageMagick were argv-recording stubs rather than the real binaries, so the comparison is
on the exact argument vector each process receives.)
